### PR TITLE
Public network support, no workers required, latest Anthos version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This ansible playbook will fully automate the prerequisits and installation of G
 
 ## Assumptions
 ### IPs
-The smallest subnet that will work is a /27
+The smallest subnet that will work is a /28
 
 The IP addresses for this deployment follow these rules:
 * Control plane node IPs are are incremented starting with the second useable IP in the range

--- a/playbooks/roles/bmctl/tasks/main.yaml
+++ b/playbooks/roles/bmctl/tasks/main.yaml
@@ -2,7 +2,7 @@
   set_fact:
     cp_vip: "{{ private_subnet | ansible.utils.nthhost('-2') }}"
     ingress_vip: "{{ private_subnet | ansible.utils.nthhost('-3') }}"
-    lb_range_start: "{{ private_subnet | ansible.utils.nthhost('-14') }}"
+    lb_range_start: "{{ private_subnet | ansible.utils.nthhost('-7') }}"
 
 - name: bmctl key
   set_fact:

--- a/playbooks/roles/bmctl/templates/bmctl.conf.j2
+++ b/playbooks/roles/bmctl/templates/bmctl.conf.j2
@@ -61,6 +61,7 @@ spec:
     containerRuntime: containerd
   nodeAccess:
     loginUser: {{ username }}
+{% if worker_node_count > 0 %}
 ---
 apiVersion: baremetal.cluster.gke.io/v1
 kind: NodePool
@@ -73,3 +74,4 @@ spec:
 {% for n in range(worker_node_count) %}
   - address: {{ private_subnet | ansible.utils.nthhost(n+5) }}
 {% endfor %}
+{% endif %}

--- a/playbooks/roles/bmctl/vars/main.yaml
+++ b/playbooks/roles/bmctl/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-bmctl_version: 1.11.1
+bmctl_version: 1.12.2
 ubuntu_docker_ce_version: 5:19.03.15~3-0~ubuntu-focal
 ubuntu_docker_ce_cli_version: 5:19.03.15~3-0~ubuntu-focal
 rhel_docker_ce_version: 3:19.03.15-3.el8

--- a/playbooks/roles/bmctl/vars/main.yaml
+++ b/playbooks/roles/bmctl/vars/main.yaml
@@ -4,4 +4,4 @@ ubuntu_docker_ce_version: 5:19.03.15~3-0~ubuntu-focal
 ubuntu_docker_ce_cli_version: 5:19.03.15~3-0~ubuntu-focal
 rhel_docker_ce_version: 3:19.03.15-3.el8
 rhel_docker_ce_cli_version: 1:19.03.15-3.el8
-kubectl_version: v1.22.8
+kubectl_version: v1.23.5


### PR DESCRIPTION
This release supports:
 * Smaller /28 subnets which is required for PNAP to use Public IPs
 * If no worker nodes are present we now skip that NodePool
 * We bumped the anthos version to: 1.12.2
 * Bumped the kubectl version to: v1.23.5