### PR TITLE
v1.0.3 Bumped Anthos version and cleaned up a bit

### DIFF
--- a/playbooks/roles/bmctl/tasks/ubuntu.yaml
+++ b/playbooks/roles/bmctl/tasks/ubuntu.yaml
@@ -60,8 +60,3 @@
     - docker
     append: yes
 
-- name: Download kubectl
-  get_url:
-    url: https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl
-    dest: /usr/local/bin/kubectl
-    mode: '0755'

--- a/playbooks/roles/bmctl/vars/main.yaml
+++ b/playbooks/roles/bmctl/vars/main.yaml
@@ -4,4 +4,4 @@ ubuntu_docker_ce_version: 5:19.03.15~3-0~ubuntu-focal
 ubuntu_docker_ce_cli_version: 5:19.03.15~3-0~ubuntu-focal
 rhel_docker_ce_version: 3:19.03.15-3.el8
 rhel_docker_ce_cli_version: 1:19.03.15-3.el8
-kubectl_version: v1.24.0
+kubectl_version: v1.24.2

--- a/playbooks/roles/bmctl/vars/main.yaml
+++ b/playbooks/roles/bmctl/vars/main.yaml
@@ -1,7 +1,7 @@
 ---
-bmctl_version: 1.12.2
+bmctl_version: 1.13.0
 ubuntu_docker_ce_version: 5:19.03.15~3-0~ubuntu-focal
 ubuntu_docker_ce_cli_version: 5:19.03.15~3-0~ubuntu-focal
 rhel_docker_ce_version: 3:19.03.15-3.el8
 rhel_docker_ce_cli_version: 1:19.03.15-3.el8
-kubectl_version: v1.23.5
+kubectl_version: v1.24.0


### PR DESCRIPTION
In this release we bumped the Anthos version to 1.13.0 and the kubectl version to 1.24.2 to match. As well as deleted a duplicate task to download kubectl defined for ubuntu only, as well as all OS types. 